### PR TITLE
Nissix plugin scope-packages on corivd-apps-e2e-boilerplate

### DIFF
--- a/corivd-apps-e2e-boilerplate/package.json
+++ b/corivd-apps-e2e-boilerplate/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "santa-integration-tests": "^2.0.0-alpha.35",
-    "sled-test-runner": "^1.0.202"
+    "@wix/santa-integration-tests": "^2.0.0-alpha.35",
+    "@wix/sled-test-runner": "^1.0.202"
   }
 }

--- a/corivd-apps-e2e-boilerplate/sled/sanity.spec.ts
+++ b/corivd-apps-e2e-boilerplate/sled/sanity.spec.ts
@@ -1,4 +1,4 @@
-/// <reference types="sled-test-runner" />
+/// <reference types="@wix/sled-test-runner" />
 import { Page } from 'puppeteer';
 
 describe('wix.com sanity', () => {


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.969s



Output Log:
Migrating package "corivd-apps-e2e-boilerplate" in corivd-apps-e2e-boilerplate


## Migration from non scope to @wix/scoped packages
> /tmp/908cf0bc45b2337c5bd03ed09fc166df/corivd-apps-e2e-boilerplate

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace reference types and shorthand ambient module types in ts & d.ts files
```
sled/sanity.spec.ts
```

