### PR TITLE
Nissix plugin scope-packages on sled-as-a-service-function

### DIFF
--- a/sled-as-a-service-lambda/index.js
+++ b/sled-as-a-service-lambda/index.js
@@ -1,5 +1,5 @@
 const { DynamoDB } = require('aws-sdk');
-const { replay } = require('sled-test-runner/dist/src/cli')
+const { replay } = require('@wix/sled-test-runner/dist/src/cli')
 
 const replayForArtifact = async event => {
     const {artifact,rcRevision} = event

--- a/sled-as-a-service-lambda/package.json
+++ b/sled-as-a-service-lambda/package.json
@@ -6,9 +6,9 @@
     "invoke": "node exec.js"
   },
   "dependencies": {
-    "sled-test-runner": "latest"
+    "@wix/sled-test-runner": "latest"
   },
   "bundledDependencies": [
-    "sled-test-runner"
+    "@wix/sled-test-runner"
   ]
 }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.328s



Output Log:
Migrating package "sled-as-a-service-function" in sled-as-a-service-lambda


## Migration from non scope to @wix/scoped packages
> /tmp/17f1b752fe9a0e97e9777fefe3ee1f41/sled-as-a-service-lambda

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
index.js
```

